### PR TITLE
Expose delay time remaining on AircraftResponse

### DIFF
--- a/sauna-api/ApiObjects/Aircraft/AircraftResponse.cs
+++ b/sauna-api/ApiObjects/Aircraft/AircraftResponse.cs
@@ -33,7 +33,7 @@ namespace SaunaSim.Api.ApiObjects.Aircraft
         public AircraftResponse(SimAircraft pilot, bool includeFms = false)
         {
             Callsign = pilot.Callsign;
-            DelayMs = pilot.DelayMs;
+            DelayMs = pilot.DelayRemainingMs;
             Paused = pilot.Paused;
             FlightPlan = pilot.FlightPlan;
             XpdrMode = pilot.XpdrMode;

--- a/sauna-sim-core/PauseableTimer.cs
+++ b/sauna-sim-core/PauseableTimer.cs
@@ -12,6 +12,7 @@ namespace SaunaSim.Core
         private double _timeMs;
         private double _timeLeftMs;
         private DateTime _started;
+        private bool _running;
 
         public event ElapsedEventHandler Elapsed;
 
@@ -46,23 +47,37 @@ namespace SaunaSim.Core
             }
             _timer.Interval = _timeLeftMs;
             _timer.Start();
+            _running = true;
         }
 
         public void Pause()
         {
             _timer.Stop();
+            _running = false;
             _timeLeftMs = _timeMs - (DateTime.UtcNow - _started).TotalMilliseconds;
         }
 
         public void Stop()
         {
             _timer.Stop();
+            _running = false;
             _timeLeftMs = _timeMs;
         }
 
         public void Dispose()
         {
             _timer.Dispose();
+        }
+
+        public int TimeRemainingMs()
+        {
+            if (!_running)
+            {
+                return (int) _timeLeftMs;
+            } else
+            {
+                return (int) (_timeMs - (DateTime.UtcNow - _started).TotalSeconds);
+            }
         }
     }
 }

--- a/sauna-sim-core/Simulator/Aircraft/SimAircraft.cs
+++ b/sauna-sim-core/Simulator/Aircraft/SimAircraft.cs
@@ -59,7 +59,7 @@ namespace SaunaSim.Core.Simulator.Aircraft
         public int Squawk { get; set; }
         public int DelayMs { get; set; }
 
-        public int DelayRemainingMs => _delayTimer.TimeRemainingMs();
+        public int DelayRemainingMs => _delayTimer?.TimeRemainingMs() ?? DelayMs;
 
         public AircraftConfig AircraftConfig { get; set; }
         public string AircraftType { get; private set; }

--- a/sauna-sim-core/Simulator/Aircraft/SimAircraft.cs
+++ b/sauna-sim-core/Simulator/Aircraft/SimAircraft.cs
@@ -58,6 +58,9 @@ namespace SaunaSim.Core.Simulator.Aircraft
         public TransponderModeType XpdrMode { get; set; }
         public int Squawk { get; set; }
         public int DelayMs { get; set; }
+
+        public int DelayRemainingMs => _delayTimer.TimeRemainingMs();
+
         public AircraftConfig AircraftConfig { get; set; }
         public string AircraftType { get; private set; }
         public string AirlineCode { get; private set; }


### PR DESCRIPTION
Needed for displaying remaining delay time on sauna-ui. Remaining time is calculated for each AircraftResponse.